### PR TITLE
SRE-1402: enforce IMDSv2 on bastion launch template

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -206,6 +206,11 @@ resource "aws_launch_template" "bastion_launch_template" {
   monitoring {
     enabled = true
   }
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
   network_interfaces {
     associate_public_ip_address = var.associate_public_ip_address
     security_groups             = concat([local.security_group], var.bastion_additional_security_groups)


### PR DESCRIPTION
## Summary
- Adds `metadata_options` block to `aws_launch_template.bastion_launch_template` requiring IMDSv2 tokens
- Closes Arnica finding flagging this fork's launch template as IMDSv1
- Mitigates SSRF-based credential theft on the internet-facing bastion (which holds an IAM instance profile)

## Context
The bastion is internet-facing (`is_lb_private = false` in [`terraform-workspace/modules/bastion/main.tf#L12`](https://github.com/OncoLens/terraform-workspace/blob/main/modules/bastion/main.tf#L12)) and there is no compensating control: confirmed via `aws ec2 get-instance-metadata-defaults` that neither `prod` nor `uat` accounts set an account-level IMDS default, and the `MissionGuardrails` SCP does not enforce `HttpTokens=required`.

`http_put_response_hop_limit = 2` is a safe default that tolerates Docker bridge networking if anything is ever added to the bastion.

## Test plan
- [x] `tofu validate` passes
- [x] `tofu fmt -check main.tf` clean
- [ ] After merge, `tofu plan` against `terraform-workspace/global/aws/bastion.tf` — expect only the launch template change
- [ ] Apply in **UAT** first, validate SSH + S3 log sync
- [ ] Promote to **prod**
- [ ] ASG instance refresh to cycle existing bastions
- [ ] Re-scan in Arnica to confirm finding is closed

Ticket: [SRE-1402](https://oncolens.youtrack.cloud/issue/SRE-1402)

🤖 Generated with [Claude Code](https://claude.com/claude-code)