### PR TITLE
SRE-1418: enforce IMDSv2 on bastion launch template

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -206,6 +206,11 @@ resource "aws_launch_template" "bastion_launch_template" {
   monitoring {
     enabled = true
   }
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
   network_interfaces {
     associate_public_ip_address = var.associate_public_ip_address
     security_groups             = concat([local.security_group], var.bastion_additional_security_groups)


### PR DESCRIPTION
## Summary

- Adds a `metadata_options` block to `aws_launch_template.bastion_launch_template` requiring IMDSv2 session tokens (`http_tokens = required`).
- Sets `http_put_response_hop_limit = 2` to stay compatible with any containerized tooling on the host.

## Why

The bastion is internet-facing (behind an ELB) and carries an IAM instance profile. IMDSv1 lets anything that can coerce an HTTP request on the host (SSRF, a proxied request) read those credentials without a token — a credible credential-theft vector. IMDSv2 forces a PUT-issued session token and, with `hop_limit = 2`, blocks naive hop-crossing SSRF.

No account-level IMDS default or SCP currently compensates. AWS guide: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-metadata-transition-to-version-2.html

Note: upstream (`Guimove`) already carries IMDSv2 support in `7de8ce6 Add IMDSV2 Support (#147)`; this PR is the minimum diff to bring the OncoLens fork into parity without pulling unrelated upstream changes.

## Test plan

- [ ] Consumers pin this merge SHA in their `source = "github.com/OncoLens/terraform-aws-bastion?ref=..."` before rolling.
- [ ] `tofu plan` in consuming workspaces shows a new launch template version + ASG instance refresh (no other unexpected diffs).
- [ ] After apply per env (UAT → staging → prod): `aws ec2 describe-instances` reports `HttpTokens=required` on new bastion instances.
- [ ] SSH to a new bastion and confirm `curl http://169.254.169.254/latest/meta-data/` (no token) returns 401, and the token-based flow succeeds.

Ticket: https://oncolens.youtrack.cloud/issue/SRE-1418

🤖 Generated with [Claude Code](https://claude.com/claude-code)